### PR TITLE
Allow spaces, hyphens, and underscores inside the replaced "@()" subs…

### DIFF
--- a/TMROLocalization/NSMutableAttributedString+Extension.swift
+++ b/TMROLocalization/NSMutableAttributedString+Extension.swift
@@ -11,7 +11,9 @@ import Foundation
 extension NSMutableAttributedString {
 
     func replace(arguments: [String]) {
-        guard let regex = try? NSRegularExpression(pattern: "@\\([a-z]*\\)",
+        // pattern matches letters, spaces, underscores & hyphens; between an openning & closing paranthesis, starting with an @ symbol
+        // e.g. @(this matches) @(this_matches-too)  @(but&NOT*punctuation!)
+        guard let regex = try? NSRegularExpression(pattern: "@\\([\\w\\s_]*\\)",
                                                    options: .caseInsensitive) else { return }
         let nsString = self.string as NSString
         let matchRanges = regex.matches(in: self.string,

--- a/TMROLocalization/NSMutableAttributedString+Extension.swift
+++ b/TMROLocalization/NSMutableAttributedString+Extension.swift
@@ -11,9 +11,9 @@ import Foundation
 extension NSMutableAttributedString {
 
     func replace(arguments: [String]) {
-        // pattern matches letters, spaces, underscores & hyphens; between an openning & closing paranthesis, starting with an @ symbol
+        // pattern matches letters, spaces, apostrophes, underscores & hyphens; between an openning & closing paranthesis, starting with an @ symbol
         // e.g. @(this matches) @(this_matches-too)  @(but&NOT*punctuation!)
-        guard let regex = try? NSRegularExpression(pattern: "@\\([\\w\\s_-]*\\)",
+        guard let regex = try? NSRegularExpression(pattern: "@\\([\\w\\s'_-]*\\)",
                                                    options: .caseInsensitive) else { return }
         let nsString = self.string as NSString
         let matchRanges = regex.matches(in: self.string,

--- a/TMROLocalization/NSMutableAttributedString+Extension.swift
+++ b/TMROLocalization/NSMutableAttributedString+Extension.swift
@@ -13,7 +13,7 @@ extension NSMutableAttributedString {
     func replace(arguments: [String]) {
         // pattern matches letters, spaces, underscores & hyphens; between an openning & closing paranthesis, starting with an @ symbol
         // e.g. @(this matches) @(this_matches-too)  @(but&NOT*punctuation!)
-        guard let regex = try? NSRegularExpression(pattern: "@\\([\\w\\s_]*\\)",
+        guard let regex = try? NSRegularExpression(pattern: "@\\([\\w\\s_-]*\\)",
                                                    options: .caseInsensitive) else { return }
         let nsString = self.string as NSString
         let matchRanges = regex.matches(in: self.string,


### PR DESCRIPTION
…trings of localized strings.

(The web team often enters ones in that format, so we should probably support them too.)

https://app.asana.com/0/1199558025235180/1200601048239976/f

**Before:**
![IMG_1003](https://user-images.githubusercontent.com/78377784/146233226-d2057345-84d7-4e5c-abab-fe7211d50dfb.PNG)

**After:**
![Screen Shot 2021-12-15 at 9 11 54 AM](https://user-images.githubusercontent.com/78377784/146233259-d4ebc30e-f0fd-4b04-aba2-04460640da8a.png)

